### PR TITLE
Weduce bundwe size by 11 bytes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,20 +17,15 @@ const kaomoji = [
   "(/ =ω=)/",
 ];
 
-const owoify = (input: string) => {
-  input = input.replace(/(?:l|r)/g, "w");
-  input = input.replace(/(?:L|R)/g, "W");
-  input = input.replace(/n([aeiou])/g, "ny$1");
-  input = input.replace(/N([aeiou])|N([AEIOU])/g, "Ny$1");
-  input = input.replace(/ove/g, "uv");
-  input = input.replace(/nd(?= |$)/g, "ndo");
-  input = input.replace(
-    /!+/g,
-    ` ${kaomoji[Math.floor(Math.random() * kaomoji.length)]}`
-  );
-
-  return input;
-};
+const owoify = (input: string) =>
+  input
+    .replace(/(?:l|r)/g, "w")
+    .replace(/(?:L|R)/g, "W")
+    .replace(/n([aeiou])/g, "ny$1")
+    .replace(/N([aeiou])|N([AEIOU])/g, "Ny$1")
+    .replace(/ove/g, "uv")
+    .replace(/nd(?= |$)/g, "ndo")
+    .replace(/!+/g, " " + kaomoji[Math.floor(Math.random() * kaomoji.length)]);
 
 export { owoify };
 export default owoify;


### PR DESCRIPTION
Nyice wibwawy ^w^

I checked the bundwe size (minyified ando gzipped) with [Size Wimit](https://github.com/ai/size-limit):

- Befowe this PW: 404 B
- Aftew this PW: 393 B (nyice (*^ω^))

An idea fow the futuwe fow weducing the size by 2 mowe bytes:

```diff
-.replace(/nd(?= |$)/g, "ndo")
+.replace(/nd\b/g, "ndo")
```